### PR TITLE
bullet-time (slow motion)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ features = ["bevy_spatial/default"]
 [package.metadata.bevy_cli.web]
 # Disable native features for web builds.
 default-features = false
-features = ["bevy_spatial/kdtree"]
+features = ["bevy_spatial/kdtree"] # TODO: add bevy/webgpu for better web perf (doesn't work for me)
 
 [package.metadata.bevy_cli.web.dev]
 features = ["dev"]

--- a/src/player/engine.rs
+++ b/src/player/engine.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 
+use avian2d::prelude::Physics;
 use bevy::{
     color::{
         ColorToComponents,
@@ -150,7 +151,7 @@ fn update_shader_params(
     mut last_particle_spawned: Local<u128>,
     mut prev_position: Local<Option<Vec2>>,
 
-    time: Res<Time>,
+    time: Res<Time<Physics>>,
 ) {
     let Some(fire_material) = materials.get_mut(*fire_material) else {
         return;

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,4 +1,4 @@
-use avian2d::prelude::LinearVelocity;
+use avian2d::prelude::{LinearVelocity, Physics, PhysicsTime};
 use bevy::{ecs::query::QueryFilter, prelude::*};
 
 pub mod assets;
@@ -13,7 +13,7 @@ pub(super) fn plugin(app: &mut App) {
         assets::plugin,
         engine::plugin,
     ))
-    .add_systems(Update, camera_follow_player);
+    .add_systems(Update, (camera_follow_player, bullet_time));
 }
 
 #[derive(Component, QueryFilter)]
@@ -44,4 +44,12 @@ fn camera_follow_player(
     // cam_transform.translation.y += -vel_len / 4.0;
 
     // cam_transform.rotation = Quat::from_rotation_x(vel_len / 70.0);
+}
+
+fn bullet_time(keys: Res<ButtonInput<KeyCode>>, mut time: ResMut<Time<Physics>>) {
+    if keys.pressed(KeyCode::Tab) {
+        time.set_relative_speed(0.25);
+    } else {
+        time.set_relative_speed(1.0);
+    }
 }

--- a/src/player/movement.rs
+++ b/src/player/movement.rs
@@ -53,7 +53,7 @@ fn thrust(
         ),
         With<Player>,
     >,
-    time: Res<Time>,
+    time: Res<Time<Physics>>,
     gas: Res<GasGenerator>,
     mut expl_ev: EventWriter<OrbExplosion>, // gas_orb_query: Query<(Entity, &Transform), With<GasOrb>>,
                                             // diagnostics: Res<DiagnosticsStore>,


### PR DESCRIPTION
- **free up space at the start**
- **another fire tweak; spawn the player motionless**
- **naive gas burning; slow**
- **fix**
- **return back basic acceleration**
- **wip**
- **fix debug call**
- **explosion queue cleanup**
- **more base speed**
- **don't print "new orbs"**
- **reduce gas attraction radius**
- **transparent gas**
- **optimized**
- **reduce memory footprint and fix a leak**
- **improve burning**
- **actually burning the gas**
- **remove unused imports**
- **dirty**
- **speed lock-in**
- **fix gas pickup**
- **better gas burning**
- **Fix systems that were not in Gameplay**
- **bullet time**
